### PR TITLE
Fix MariaDB configuration

### DIFF
--- a/srcs/requirements/mariadb/Dockerfile
+++ b/srcs/requirements/mariadb/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends mariadb-server procps && \
     rm -rf /var/lib/apt/lists/*
 
+COPY conf/my.cnf /etc/mysql/conf.d/
+
 COPY tools/entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/srcs/requirements/mariadb/conf/my.cnf
+++ b/srcs/requirements/mariadb/conf/my.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+skip-host-cache
+skip-name-resolve
+bind-address=0.0.0.0

--- a/srcs/requirements/mariadb/tools/entrypoint.sh
+++ b/srcs/requirements/mariadb/tools/entrypoint.sh
@@ -15,8 +15,10 @@ if [ ! -d "/var/lib/mysql/mysql" ]; then
     done
 
     mysql --socket=/run/mysqld/mysqld.sock <<-EOSQL
-        SET PASSWORD FOR 'root'@'localhost' = PASSWORD('$(cat ${MYSQL_ROOT_PASSWORD_FILE})');
+        ALTER USER 'root'@'localhost' IDENTIFIED BY '$(cat ${MYSQL_ROOT_PASSWORD_FILE})';
         DELETE FROM mysql.user WHERE User='';
+        DROP DATABASE IF EXISTS test;
+        DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
         CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\`;
         CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'%' IDENTIFIED BY '$(cat ${MYSQL_PASSWORD_FILE})';
         GRANT ALL PRIVILEGES ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%';


### PR DESCRIPTION
## Summary
- harden MariaDB entrypoint with user creation and DB cleanup
- provide minimal my.cnf
- copy configuration into the MariaDB image

## Testing
- `docker compose -f srcs/docker-compose.yml config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685419acfde48328b4a5198720a3dc89